### PR TITLE
!feat: Add Pulsar-Cooperative Template Files & Update Existing Files

### DIFF
--- a/.github/issue-comment-template.md
+++ b/.github/issue-comment-template.md
@@ -1,0 +1,11 @@
+# Welcome to Pulsar Cooperative: {{ .repo }}!
+
+Thanks a ton [{{ .user }}]({{ .userLink }}) for creating this issue! We can't understate how important and appreciated it is for your contribution!
+
+However, it's important to be clear about the level of support that should be expected here.
+
+As this repository is within the [Pulsar Cooperative Organization](https://github.com/pulsar-cooperative), you cannot expect any core members of the Pulsar Organization to offer advice or code fixes. The fix to your issue is expected to come from someone else in the community just like yourself, as is the mission of this organization. If you'd like, feel free to read more about this in our organization's [Contributing Guide](https://github.com/pulsar-cooperative/.github/blob/main/CONTRIBUTING.md).
+
+Hope your issue is resolved soon, and as always, see you among the stars!
+
+- The Pulsar Team

--- a/.github/rebrand-issue-template.md
+++ b/.github/rebrand-issue-template.md
@@ -1,0 +1,15 @@
+---
+title: Rebrand this Repository
+labels: good first issue
+---
+This repository may or may not contain items that still need to be rebranded after having been forked.
+This may include but is not limited to:
+
+  * `README.md`
+  * `CONTRIBUTING.md`
+  * `package.json`
+  * `./keymaps/`
+  * `./menus/`
+  * `./lib/`
+
+It's most important to rebrand any items that are keymaps, menu items, or appear in the `package.json`. But of course it's important to ensure the entire package has been rebranded to the new package name, as well as replacing Atom with Pulsar where applicable.

--- a/.github/workflows/comment-issues.yml
+++ b/.github/workflows/comment-issues.yml
@@ -1,0 +1,29 @@
+name: Comment on New Issues
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Render Comment Template
+        id: template
+        uses: chuhlomin/render-template@v1.4
+        with:
+          template: .github/issue-comment-template.md
+          vars: |
+            user: ${{ github.event.issue.user.login }}
+            userLink: ${{ github.event.issue.user.html_url }}
+            repo: ${{ github.repository }}
+
+      - name: Add Comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: ${{ steps.template.outputs.result }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish Package for the First Time
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    # We need to have at least one tag available prior to publication. So we will publish the first release
+    # during publication.
+    - name: Checkout the Latest Package Code
+      uses: actions/checkout@v3
+    - name: Get Version
+      id: version
+      run: node -p "'version=' + require('./package.json').version" >> "$GITHUB_OUTPUT"
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.version.outputs.version }}
+    # Now this is what's needed to actually publish the package to PPR
+    - name: Publish Package to PPR
+      if: ${{ vars.PUBLISHED != 'true' }}
+      run: |
+        curl -X POST -H \
+          "Authorization: ${{ secrets.PPR_AUTH }}" \
+          https://api.pulsar-edit.dev/api/packages?repository=${{ github.repository }}
+    - name: Create Repository's 'PUBLISH' Var
+      run: |
+        curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.REPO_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/pulsar-cooperative/${{ vars.REPO_NAME }}/actions/variables \
+          -d '{"name":"PUBLISHED","value":"true"}'
+    - name: Create Rebrand Issue in Repo
+      uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      with:
+        filename: .github/rebrand-issue-template.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release New Version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Publish Version to PPR
+        if: ${{ vars.PUBLISHED == 'true' }}
+        run: |
+          curl -X POST \
+            -H "Authorization: ${{ secrets.PPR_AUTH }}" \
+            https://api.pulsar-edit.dev/api/packages/${{ github.event.repository.name }}/versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: choco install shellcheck
       - name: Install Shellcheck (Linux)
         if: ${{ runner.os == 'Linux' }}
-        run: apt install shellcheck
+        run: sudo apt install shellcheck
       - name: Install Shellcheck (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: brew install shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-latest, windows-2019]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout the Latest Package Code
+        uses: actions/checkout@v3
+      - name: Setup Pulsar Editor
+        uses: pulsar-edit/action-pulsar-dependency@v3.3
+      - name: Install dependencies (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: ppm install --verbose
+      - name: Install Dependencies (*nix)
+        if: ${{ runner.os != 'Windows' }}
+        run: pulsar --package install --verbose
+
+      # Here we differ from the template files, since we need to install
+      # shellcheck, as it's required by this package
+      # https://github.com/koalaman/shellcheck
+      - name: Install Shellcheck (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: choco install shellcheck
+      - name: Install Shellcheck (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: apt install shellcheck
+      - name: Install Shellcheck (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: brew install shellcheck
+      # <END Template Differ>
+
+      - name: Run the headless Pulsar Tests
+        uses: coactions/setup-xvfb@v1.0.1
+        with:
+          run: pulsar --test spec

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,23 @@
+name: Bump Package Version
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - name: Bump Version
+      if: ${{ vars.PUBLISHED == 'true' }}
+      uses: google-github-actions/release-please-action@v3
+      with:
+        release-type: node
+        package-name: ${{ vars.REPO_NAME }}
+        token: ${{ secrets.REPO_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+<!-- Pulsar Cooperative Package Repository Template, place at the start of the original CONTRIBUTING document -->
+
+To learn how to contribute to any repository within the Pulsar Cooperative Organization, ensure to read the [Contributing Guide](https://github.com/pulsar-cooperative/.github/blob/main/CONTRIBUTING.md) for the org.
+Otherwise, below is the original contributing documentation for this repository. This information has not been updated or modified from how the original developers had written it, so if there is any conflicting information between this document and the organization wide contributing document, the organization wide document should **always** take precedence, and be regarded as the source of truth for how to contribute.
+
+Thanks for taking the time to contribute and make Pulsar Cooperative, truly a Cooperative effort!
+
+<!-- Original Contributing Document to follow -->
+---
+
 If you would like to contribute enhancements or fixes, please do the following:
 
 1.  Fork the plugin repository.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# linter-shellcheck
+# linter-shellcheck-pulsar
 
 <!-- Pulsar Cooperative Package Repository Template, place underneath the first h1 heading in the original readme -->
 
@@ -28,14 +28,14 @@ your system. To install `shellcheck`, follow the guide on
 ### Plugin installation
 
 ```ShellSession
-apm install linter-shellcheck
+ppm install linter-shellcheck-pulsar
 ```
 
 ## Settings
 
-You can configure linter-shellcheck through Atom's Settings menu. If you
+You can configure linter-shellcheck-pulsar through Pulsar's Settings menu. If you
 instead prefer editing the configuration by hand you can get to that by editing
-`~/.atom/config.cson` (choose Open Your Config in Atom menu). The settings
+`~/.atom/config.cson` (choose Open Your Config in Pulsar menu). The settings
 available are:
 
 -   `shellcheckExecutablePath`: The full path to the `shellcheck` executable.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <!-- Pulsar Cooperative Package Repository Template, place underneath the first h1 heading in the original readme -->
 
 > [!NOTE]
-> This package was originally created by <ORIGINAL_AUTHORS_NAME> and has now been forked under the [`pulsar-cooperative`](https://github.com/pulsar-cooperative) organization.
-> By forking this package we hope to allow new maintainers to work on this package as needed, without being limited by its previous [archived/unmaintained] status, helping to ensure this package stays up to date and functional for as long as possible without the huge responsibility implied by forking and maintaining this under a personal account.
+> This package was originally created by AtomLinter and has now been forked under the [`pulsar-cooperative`](https://github.com/pulsar-cooperative) organization.
+> By forking this package we hope to allow new maintainers to work on this package as needed, without being limited by its previous archived status, helping to ensure this package stays up to date and functional for as long as possible without the huge responsibility implied by forking and maintaining this under a personal account.
 >
 > For more info on the Pulsar Cooperative initiative please read [the documentation](https://github.com/pulsar-cooperative/.github/blob/main/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # linter-shellcheck
 
+<!-- Pulsar Cooperative Package Repository Template, place underneath the first h1 heading in the original readme -->
+
+> [!NOTE]
+> This package was originally created by <ORIGINAL_AUTHORS_NAME> and has now been forked under the [`pulsar-cooperative`](https://github.com/pulsar-cooperative) organization.
+> By forking this package we hope to allow new maintainers to work on this package as needed, without being limited by its previous [archived/unmaintained] status, helping to ensure this package stays up to date and functional for as long as possible without the huge responsibility implied by forking and maintaining this under a personal account.
+>
+> For more info on the Pulsar Cooperative initiative please read [the documentation](https://github.com/pulsar-cooperative/.github/blob/main/CONTRIBUTING.md).
+
+<!-- Original Readme to follow -->
+
 This linter plugin for [Linter][linter] provides an interface to
 [shellcheck][shellcheck]. It will be used with files that have the "Shell"
 syntax.
@@ -41,7 +51,7 @@ available are:
     [`source=`](https://github.com/koalaman/shellcheck/wiki/Directive#source)
     directive are relative to the project root or the file (default: false, for
     file-relative)
-    
+
     -   If true, ShellCheck's working directory
         will be the project's root directory.  Any `source=` directives will be
         interpreted relative to the project root.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "linter-shellcheck",
+  "name": "linter-shellcheck-pulsar",
   "main": "./lib/main.js",
   "version": "1.6.0",
   "private": true,
   "description": "Lint Bash on the fly, using shellcheck",
-  "repository": "https://github.com/AtomLinter/linter-shellcheck",
+  "repository": "https://github.com/pulsar-cooperative/linter-shellcheck-pulsar",
   "license": "MIT",
   "engines": {
     "atom": ">=1.4.0 <2.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "language-shellscript:grammar-used"
   ],
   "scripts": {
-    "test": "apm test",
+    "test": "ppm test",
     "lint": "eslint ."
   },
   "configSchema": {


### PR DESCRIPTION
This PR adds all template files from [`.github`](https://github.com/pulsar-cooperative/.github) to this repository.

Additionally, this PR modifies the GHA test workflows to ensure we install `shellcheck` as a dependency. We also preform some slight rebranding in this repository, mainly within the `README.md` and `package.json` so rebranding is still required in the rest of the package.