### PR TITLE
feat!: Fix errors in tests

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,7 @@ const createURL = (text) => {
 
 export default {
   activate() {
-    require('atom-package-deps').install('linter-shellcheck');
+    require('atom-package-deps').install('linter-shellcheck-pulsar');
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,16 +23,16 @@ export default {
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
-      atom.config.observe('linter-shellcheck.shellcheckExecutablePath', (value) => {
+      atom.config.observe('linter-shellcheck-pulsar.shellcheckExecutablePath', (value) => {
         this.executablePath = value;
       }),
-      atom.config.observe('linter-shellcheck.enableNotice', (value) => {
+      atom.config.observe('linter-shellcheck-pulsar.enableNotice', (value) => {
         this.enableNotice = value;
       }),
-      atom.config.observe('linter-shellcheck.userParameters', (value) => {
+      atom.config.observe('linter-shellcheck-pulsar.userParameters', (value) => {
         this.userParameters = value.trim().split(' ').filter(Boolean);
       }),
-      atom.config.observe('linter-shellcheck.useProjectCwd', (value) => {
+      atom.config.observe('linter-shellcheck-pulsar.useProjectCwd', (value) => {
         this.useProjectCwd = value;
       }),
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "linter-shellcheck",
+  "name": "linter-shellcheck-pulsar",
   "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/spec/linter-shellcheck-spec.js
+++ b/spec/linter-shellcheck-spec.js
@@ -36,7 +36,7 @@ describe('The ShellCheck provider for Linter', () => {
   });
 
   it('handles messages from ShellCheck', async () => {
-    const expectedExcerpt = 'Tips depend on target shell and yours is unknown. Add a shebang. [SC2148]';
+    const expectedExcerpt = 'Tips depend on target shell and yours is unknown. Add a shebang or a `shell` directive. [SC2148]';
     const expectedURL = 'https://github.com/koalaman/shellcheck/wiki/SC2148';
     const editor = await atom.workspace.open(badPath);
     const messages = await lint(editor);

--- a/spec/linter-shellcheck-spec.js
+++ b/spec/linter-shellcheck-spec.js
@@ -36,14 +36,17 @@ describe('The ShellCheck provider for Linter', () => {
   });
 
   it('handles messages from ShellCheck', async () => {
-    const expectedExcerpt = "Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]";
+    const expectedExcerpt = [
+      "Tips depend on target shell and yours is unknown. Add a shebang. [SC2148]",
+      "Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]"
+    ];
     const expectedURL = 'https://github.com/koalaman/shellcheck/wiki/SC2148';
     const editor = await atom.workspace.open(badPath);
     const messages = await lint(editor);
 
     expect(messages.length).toBe(1);
     expect(messages[0].severity).toBe('error');
-    expect(messages[0].excerpt).toBe(expectedExcerpt);
+    expect(expectedExcerpt.includes(messages[0].excerpt)).toBe(true);
     expect(messages[0].url).toBe(expectedURL);
     expect(messages[0].location.file).toBe(badPath);
     expect(messages[0].location.position).toEqual([[0, 0], [0, 4]]);

--- a/spec/linter-shellcheck-spec.js
+++ b/spec/linter-shellcheck-spec.js
@@ -19,7 +19,7 @@ describe('The ShellCheck provider for Linter', () => {
 
     // Info about this beforeEach() implementation:
     // https://github.com/AtomLinter/Meta/issues/15
-    const activationPromise = atom.packages.activatePackage('linter-shellcheck');
+    const activationPromise = atom.packages.activatePackage('linter-shellcheck-pulsar');
 
     await atom.packages.activatePackage('language-shellscript');
     await atom.workspace.open(cleanPath);
@@ -51,19 +51,19 @@ describe('The ShellCheck provider for Linter', () => {
 
   describe('implements useProjectCwd and', () => {
     beforeEach(async () => {
-      atom.config.set('linter-shellcheck.userParameters', '-x');
-      atom.config.set('linter-shellcheck.enableNotice', true);
+      atom.config.set('linter-shellcheck-pulsar.userParameters', '-x');
+      atom.config.set('linter-shellcheck-pulsar.enableNotice', true);
     });
 
     it('uses file-relative source= directives by default', async () => {
-      atom.config.set('linter-shellcheck.useProjectCwd', false);
+      atom.config.set('linter-shellcheck-pulsar.useProjectCwd', false);
       const editor = await atom.workspace.open(sourceFileRelativePath);
       const messages = await lint(editor);
       expect(messages.length).toBe(0);
     });
 
     it('errors for file-relative source= path with useProjectCwd = true', async () => {
-      atom.config.set('linter-shellcheck.useProjectCwd', true);
+      atom.config.set('linter-shellcheck-pulsar.useProjectCwd', true);
       const editor = await atom.workspace.open(sourceFileRelativePath);
       const messages = await lint(editor);
       expect(messages.length).toBe(1);
@@ -71,14 +71,14 @@ describe('The ShellCheck provider for Linter', () => {
     });
 
     it('uses project-relative source= directives via setting (based at fixtures/)', async () => {
-      atom.config.set('linter-shellcheck.useProjectCwd', true);
+      atom.config.set('linter-shellcheck-pulsar.useProjectCwd', true);
       const editor = await atom.workspace.open(sourceProjectRelativePath);
       const messages = await lint(editor);
       expect(messages.length).toBe(0);
     });
 
     it('errors for project-relative source= path with useProjectCwd = false (based at fixtures/)', async () => {
-      atom.config.set('linter-shellcheck.useProjectCwd', false);
+      atom.config.set('linter-shellcheck-pulsar.useProjectCwd', false);
       const editor = await atom.workspace.open(sourceProjectRelativePath);
       const messages = await lint(editor);
       expect(messages.length).toBe(1);

--- a/spec/linter-shellcheck-spec.js
+++ b/spec/linter-shellcheck-spec.js
@@ -36,7 +36,7 @@ describe('The ShellCheck provider for Linter', () => {
   });
 
   it('handles messages from ShellCheck', async () => {
-    const expectedExcerpt = 'Tips depend on target shell and yours is unknown. Add a shebang or a `shell` directive. [SC2148]';
+    const expectedExcerpt = "Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive. [SC2148]";
     const expectedURL = 'https://github.com/koalaman/shellcheck/wiki/SC2148';
     const editor = await atom.workspace.open(badPath);
     const messages = await lint(editor);


### PR DESCRIPTION
Seems the errors causing failures in testing were actually the result of rebranding not yet completed.

This PR rebrands the calls to the config API to use the new package name.